### PR TITLE
Modify PUMAS with NorESM-specific modifications

### DIFF
--- a/micro_mg1_0.F90
+++ b/micro_mg1_0.F90
@@ -400,17 +400,19 @@ subroutine micro_mg_tend ( &
      nsout2, drout2, dsout2, freqs, freqr,            &
      nfice, prer_evap, do_cldice, errstring,          &
      tnd_qsnow, tnd_nsnow, re_ice,                    &
-     frzimm, frzcnt, frzdep      ,                    &
-!AL
-     nnuccco, nnuccto, npsacwso, nsubco, nprao,       &
+     frzimm, frzcnt, frzdep                           &
+!AL++
+#ifdef OSLO_AERO
+    ,nnuccco, nnuccto, npsacwso, nsubco, nprao,       &
      nprc1o, nqcsedten, nqisedten, nmelto, nhomoo,    &
      nimelto, nihomoo, nsacwio, nsubio, nprcio,       &
      npraio, nnudepo, npccno, nnuccdo, mnudepo,       &
      nctncons,nctnnbmn,nctnszmn,                      &
      nctnszmx,nctnncld,nitncons,nitnszmn,             &
-     nitnszmx,nitnncld)                              
-
-!AL
+     nitnszmx,nitnncld                                &                              
+#endif
+!AL--
+     )
 
 ! input arguments
 logical,  intent(in) :: microp_uniform  ! True = configure uniform for sub-columns  False = use w/o sub-columns (standard)
@@ -530,7 +532,8 @@ real(r8), intent(out) :: prer_evap(pcols,pver)
 real(r8) :: nevapr2(pcols,pver)
 
 character(128),   intent(out) :: errstring       ! Output status (non-blank for error return)
-!AL
+!AL++
+#ifdef OSLO_AERO
 real(r8), intent(out) :: nnuccco(pcols,pver)   ! immersion freezing
 real(r8), intent(out) :: nnuccto(pcols,pver)   ! contact freezing
 real(r8), intent(out) :: npsacwso(pcols,pver)  ! accr. snow
@@ -560,7 +563,8 @@ real(r8), intent(out) :: nitncons(pcols,pver)  ! ni tuning to conserve number in
 real(r8), intent(out) :: nitnszmn(pcols,pver)  ! ni tuning: minimum slope
 real(r8), intent(out) :: nitnszmx(pcols,pver)  ! ni tuning: maximum slope
 real(r8), intent(out) :: nitnncld(pcols,pver)  ! ni tuning: removal of ni when qi is zero after mg
-!AL
+#endif
+!AL--
 
 
 
@@ -948,7 +952,8 @@ meltsdt(1:ncol,1:pver)=0._r8
 frzrdt (1:ncol,1:pver)=0._r8
 mnuccdo(1:ncol,1:pver)=0._r8
 
-!AL
+!AL++
+#ifdef OSLO_AERO
 nnuccco(1:ncol,1:pver)=0._r8 
 nnuccto(1:ncol,1:pver)=0._r8 
 npsacwso(1:ncol,1:pver)=0._r8
@@ -978,8 +983,8 @@ nitncons(1:ncol,1:pver)=0._r8
 nitnszmn(1:ncol,1:pver)=0._r8 
 nitnszmx(1:ncol,1:pver)=0._r8 
 nitnncld(1:ncol,1:pver)=0._r8 
-
-!AL
+#endif
+!AL--
 
 
 rflx(:,:)=0._r8
@@ -1977,12 +1982,14 @@ do i=1,ncol
 
          if (.not. use_hetfrz_classnuc) then
 
-!AL
+!AL++
 !Make sure zero output for deposition freezing
 !If no classnuc this is included in NNUCCD (Meyers 1992)
+#ifdef OSLO_AERO
             nnudep(k) = 0.0_r8
             mnudep(k) = 0.0_r8
-!AL
+#endif
+!AL--
             if (do_cldice .and. qcic(i,k).ge.qsmall .and. t(i,k).lt.269.15_r8) then
 
                ! immersion freezing (Bigg, 1953)
@@ -2646,7 +2653,8 @@ do i=1,ncol
          praio(i,k)=praio(i,k)+prai(k)*icldm(i,k)
          mnuccro(i,k)=mnuccro(i,k)+mnuccr(k)*cldmax(i,k)
          pracso (i,k)=pracso (i,k)+pracs (k)*cldmax(i,k)
-!AL
+!AL++
+#ifdef OSLO_AERO
          mnudepo(i,k)=mnudepo(i,k)+mnudep(k)*lcldm(i,k)  
 
          ! microphysics output for number concentration tendencies
@@ -2666,7 +2674,8 @@ do i=1,ncol
          npraio(i,k)=npraio(i,k)+nprai(k)*icldm(i,k) 
          nnudepo(i,k)=nnudepo(i,k)+nnudep(k)*lcldm(i,k)  
          nnuccdo(i,k)=nnuccdo(i,k)+nnuccd(k)*mtime      
-!AL
+#endif
+!AL--
 
          ! multiply activation/nucleation by mtime to account for fast timescale
 
@@ -2695,12 +2704,20 @@ do i=1,ncol
          ! fast nucleation timescale
 
          if (nctend(i,k).gt.0._r8.and.nc(i,k)+nctend(i,k)*deltat.gt.ncmax) then
+!AL++
+#ifdef OSLO_AERO
             nctncons(i,k) = nctncons(i,k) + nctend(i,k)-max(0._r8,(ncmax-nc(i,k))/deltat) !AL
+#endif
+!AL--
             nctend(i,k)=max(0._r8,(ncmax-nc(i,k))/deltat)
          end if
 
          if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax) then
+!AL++
+#ifdef OSLO_AERO
             nitncons(i,k) = nitncons(i,k) + nitend(i,k)-max(0._r8,(nimax-ni(i,k))/deltat) !AL
+#endif
+!AL--
             nitend(i,k)=max(0._r8,(nimax-ni(i,k))/deltat)
          end if
 
@@ -3099,7 +3116,8 @@ do i=1,ncol
 
       mnuccdo(i,k)=mnuccdo(i,k)/real(iter)
 
-!AL
+#ifdef OSLO_AERO
+!AL++
       mnudepo(i,k)=mnudepo(i,k)/real(iter)   
       nnuccco(i,k)=nnuccco(i,k)/real(iter)   
       nnuccto(i,k)=nnuccto(i,k)/real(iter)   
@@ -3116,8 +3134,8 @@ do i=1,ncol
       npccno(i,k)=npccno(i,k)/real(iter)   
       nctncons(i,k)=nctncons(i,k)/real(iter)  
       nitncons(i,k)=nitncons(i,k)/real(iter)  
-!AL
-
+#endif
+!AL--
       ! modify to include snow. in prain & evap (diagnostic here: for wet dep)
       nevapr(i,k) = nevapr(i,k) + evapsnow(i,k)
       prer_evap(i,k) = nevapr2(i,k)
@@ -3262,10 +3280,12 @@ do i=1,ncol
       ! sedimentation tendencies for output
       qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
       qisedten(i,k)=qisedten(i,k)-faltndi/nstep
-!AL
+!AL++
+#ifdef OSLO_AERO
       nqcsedten(i,k)=nqcsedten(i,k)-faltndnc/nstep
       nqisedten(i,k)=nqisedten(i,k)-faltndni/nstep
-!AL
+#endif
+!AL--
 
       dumi(i,k) = dumi(i,k)-faltndi*deltat/nstep
       dumni(i,k) = dumni(i,k)-faltndni*deltat/nstep
@@ -3301,10 +3321,12 @@ do i=1,ncol
          ! sedimentation tendencies for output
          qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
          qisedten(i,k)=qisedten(i,k)-faltndi/nstep
-!AL
+!AL++
+#ifdef OSLO_AERO
          nqcsedten(i,k)=nqcsedten(i,k)-faltndnc/nstep
          nqisedten(i,k)=nqisedten(i,k)-faltndni/nstep
-!AL
+#endif
+!AL--
          ! add terms to to evap/sub of cloud water
 
          qvlat(i,k)=qvlat(i,k)-(faltndqie-faltndi)/nstep
@@ -3395,12 +3417,14 @@ do i=1,ncol
 
                nctend(i,k)=nctend(i,k)+3._r8*dum*dumi(i,k)/deltat/ &
                     (4._r8*pi*5.12e-16_r8*rhow)
-!AL
+!AL++
+#ifdef OSLO_AERO
                ! for output
                nmelto(i,k)=3._r8*dum*dumi(i,k)/deltat/ &
                     (4._r8*pi*5.12e-16_r8*rhow)
                nimelto(i,k)=nitend(i,k)-((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
-!AL
+#endif
+!AL--
                qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))/deltat
                nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
                tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)/deltat
@@ -3432,11 +3456,13 @@ do i=1,ncol
                nitend(i,k)=nitend(i,k)+dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
                     500._r8)/deltat
                qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))/deltat
-!AL
+!AL++
+#ifdef OSLO_AERO
                nhomoo(i,k)=nctend(i,k)-((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
                nihomoo(i,k)=dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
                     500._r8)/deltat
-!AL
+#endif
+!AL--
                nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
                tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)/deltat
             end if
@@ -3529,7 +3555,11 @@ do i=1,ncol
             niic(i,k) = n0i(k)/lami(k)
             ! adjust number conc if needed to keep mean size in reasonable range
             if (do_cldice) then
+!AL++
+#ifdef OSLO_AERO
                nitnszmn(i,k)=nitnszmn(i,k) + nitend(i,k)-(niic(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
+#endif
+!AL--
                nitend(i,k)=(niic(i,k)*icldm(i,k)-ni(i,k))/deltat
             endif
          else if (lami(k).gt.lammaxi) then
@@ -3538,7 +3568,11 @@ do i=1,ncol
             niic(i,k) = n0i(k)/lami(k)
             ! adjust number conc if needed to keep mean size in reasonable range
             if (do_cldice)then
+!AL++
+#ifdef OSLO_AERO
                nitnszmx(i,k)=nitnszmx(i,k) + nitend(i,k)-(niic(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
+#endif
+!AL--
                nitend(i,k)=(niic(i,k)*icldm(i,k)-ni(i,k))/deltat
             endif
          end if
@@ -3575,9 +3609,11 @@ do i=1,ncol
          ! after update by microphysics, except when lambda exceeds bounds on mean drop
          ! size or if there is no cloud water
          if (dumnc(i,k).lt.cdnl/rho(i,k)) then
-!AL
+!AL++
+#ifdef OSLO_AERO
             nctnnbmn(i,k)=nctnnbmn(i,k) + nctend(i,k)-(cdnl/rho(i,k)*lcldm(i,k)-nc(i,k))/deltat
-!AL 
+#endif
+!AL--
             nctend(i,k)=(cdnl/rho(i,k)*lcldm(i,k)-nc(i,k))/deltat  
          end if
          dumnc(i,k)=max(dumnc(i,k),cdnl/rho(i,k)) ! sghan minimum in #/cm3 
@@ -3598,9 +3634,11 @@ do i=1,ncol
                  gamma(pgam(k)+1._r8)/ &
                  (pi*rhow*gamma(pgam(k)+4._r8))
             ! adjust number conc if needed to keep mean size in reasonable range
-!AL
+!AL++
+#ifdef OSLO_AERO
             nctnszmn(i,k)=nctnszmn(i,k) + nctend(i,k)-(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
-!AL 
+#endif
+!AL-- 
             nctend(i,k)=(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
 
          else if (lamc(k).gt.lammax) then
@@ -3609,9 +3647,11 @@ do i=1,ncol
                  gamma(pgam(k)+1._r8)/ &
                  (pi*rhow*gamma(pgam(k)+4._r8))
             ! adjust number conc if needed to keep mean size in reasonable range
-!AL
+!AL++
+#ifdef OSLO_AERO
             nctnszmx(i,k)=nctnszmx(i,k) + nctend(i,k)-(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
-!AL 
+#endif
+!AL-- 
             nctend(i,k)=(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
          end if
 
@@ -3676,11 +3716,19 @@ do i=1,ncol
       ! if updated q (after microphysics) is zero, then ensure updated n is also zero
 
       if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) then !AL
+!AL++
+#ifdef OSLO_AERO
          nctnncld(i,k) = nctnncld(i,k) + nctend(i,k) +nc(i,k)/deltat
+#endif
+!AL--
          nctend(i,k)=-nc(i,k)/deltat
       endif
       if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall)then !AL
+!AL++
+#ifdef OSLO_AERO
          nitnncld(i,k) = nitnncld(i,k) + nitend(i,k) +ni(i,k)/deltat
+#endif
+!AL--
          nitend(i,k)=-ni(i,k)/deltat
       endif
    end do

--- a/micro_mg1_0.F90
+++ b/micro_mg1_0.F90
@@ -400,7 +400,17 @@ subroutine micro_mg_tend ( &
      nsout2, drout2, dsout2, freqs, freqr,            &
      nfice, prer_evap, do_cldice, errstring,          &
      tnd_qsnow, tnd_nsnow, re_ice,                    &
-     frzimm, frzcnt, frzdep)
+     frzimm, frzcnt, frzdep      ,                    &
+!AL
+     nnuccco, nnuccto, npsacwso, nsubco, nprao,       &
+     nprc1o, nqcsedten, nqisedten, nmelto, nhomoo,    &
+     nimelto, nihomoo, nsacwio, nsubio, nprcio,       &
+     npraio, nnudepo, npccno, nnuccdo, mnudepo,       &
+     nctncons,nctnnbmn,nctnszmn,                      &
+     nctnszmx,nctnncld,nitncons,nitnszmn,             &
+     nitnszmx,nitnncld)                              
+
+!AL
 
 ! input arguments
 logical,  intent(in) :: microp_uniform  ! True = configure uniform for sub-columns  False = use w/o sub-columns (standard)
@@ -520,6 +530,39 @@ real(r8), intent(out) :: prer_evap(pcols,pver)
 real(r8) :: nevapr2(pcols,pver)
 
 character(128),   intent(out) :: errstring       ! Output status (non-blank for error return)
+!AL
+real(r8), intent(out) :: nnuccco(pcols,pver)   ! immersion freezing
+real(r8), intent(out) :: nnuccto(pcols,pver)   ! contact freezing
+real(r8), intent(out) :: npsacwso(pcols,pver)  ! accr. snow
+real(r8), intent(out) :: nsubco(pcols,pver)    ! evaporation of droplet 
+real(r8), intent(out) :: nprao(pcols,pver)     ! accretion
+real(r8), intent(out) :: nprc1o(pcols,pver)    ! autoconversion
+real(r8), intent(out) :: nqcsedten(pcols,pver) ! nqc sedimentation tendency
+real(r8), intent(out) :: nqisedten(pcols,pver) ! nqc sedimentation tendency
+real(r8), intent(out) :: nmelto(pcols,pver)    ! melting of cloud ice
+real(r8), intent(out) :: nhomoo(pcols,pver)    ! homogeneos freezign cloud water
+real(r8), intent(out) :: nimelto(pcols,pver)   ! melting of cloud ice
+real(r8), intent(out) :: nihomoo(pcols,pver)   ! homogeneos freezign cloud water
+real(r8), intent(out) :: nsacwio(pcols,pver)   ! numb conc tend due to HM ice multiplication
+real(r8), intent(out) :: nsubio(pcols,pver)    ! evaporation of cloud ice number (sublimation?)
+real(r8), intent(out) :: nprcio(pcols,pver)    ! numb conc tend due to auto of cloud ice to snow
+real(r8), intent(out) :: npraio(pcols,pver)    ! numb conc tend due to accr of cloud ice by snow
+real(r8), intent(out) :: nnudepo(pcols,pver)   ! deposition?
+real(r8), intent(out) :: npccno(pcols,pver)    ! activation
+real(r8), intent(out) :: nnuccdo(pcols,pver)   ! ni nucleation
+real(r8), intent(out) :: mnudepo(pcols,pver)   ! deposition (mass)
+real(r8), intent(out) :: nctncons(pcols,pver)  ! nc tuning to conserve number in substeps
+real(r8), intent(out) :: nctnnbmn(pcols,pver)  ! nc tuning: minimum droplet number
+real(r8), intent(out) :: nctnszmn(pcols,pver)  ! nc tuning: minimum slope
+real(r8), intent(out) :: nctnszmx(pcols,pver)  ! nc tuning: maximum slope
+real(r8), intent(out) :: nctnncld(pcols,pver)  ! nc tuning: removal of nc when qc is zero after mg
+real(r8), intent(out) :: nitncons(pcols,pver)  ! ni tuning to conserve number in substeps
+real(r8), intent(out) :: nitnszmn(pcols,pver)  ! ni tuning: minimum slope
+real(r8), intent(out) :: nitnszmx(pcols,pver)  ! ni tuning: maximum slope
+real(r8), intent(out) :: nitnncld(pcols,pver)  ! ni tuning: removal of ni when qi is zero after mg
+!AL
+
+
 
 ! Tendencies calculated by external schemes that can replace MG's native
 ! process tendencies.
@@ -904,6 +947,40 @@ pracso (1:ncol,1:pver)=0._r8
 meltsdt(1:ncol,1:pver)=0._r8
 frzrdt (1:ncol,1:pver)=0._r8
 mnuccdo(1:ncol,1:pver)=0._r8
+
+!AL
+nnuccco(1:ncol,1:pver)=0._r8 
+nnuccto(1:ncol,1:pver)=0._r8 
+npsacwso(1:ncol,1:pver)=0._r8
+nsubco(1:ncol,1:pver)=0._r8  
+nprao(1:ncol,1:pver)=0._r8   
+nprc1o(1:ncol,1:pver)=0._r8  
+nqcsedten(1:ncol,1:pver)=0._r8
+nmelto(1:ncol,1:pver)=0._r8 
+nhomoo(1:ncol,1:pver)=0._r8 
+nqisedten(1:ncol,1:pver)=0._r8
+nimelto(1:ncol,1:pver)=0._r8 
+nihomoo(1:ncol,1:pver)=0._r8 
+nsacwio(1:ncol,1:pver)=0._r8 
+nsubio(1:ncol,1:pver)=0._r8  
+nprcio(1:ncol,1:pver)=0._r8  
+npraio(1:ncol,1:pver)=0._r8  
+nnudepo(1:ncol,1:pver)=0._r8 
+mnudepo(1:ncol,1:pver)=0._r8 
+npccno(1:ncol,1:pver)=0._r8 
+nnuccdo(1:ncol,1:pver)=0._r8 
+nctncons(1:ncol,1:pver)=0._r8 
+nctnnbmn(1:ncol,1:pver)=0._r8 
+nctnszmn(1:ncol,1:pver)=0._r8 
+nctnszmx(1:ncol,1:pver)=0._r8 
+nctnncld(1:ncol,1:pver)=0._r8 
+nitncons(1:ncol,1:pver)=0._r8 
+nitnszmn(1:ncol,1:pver)=0._r8 
+nitnszmx(1:ncol,1:pver)=0._r8 
+nitnncld(1:ncol,1:pver)=0._r8 
+
+!AL
+
 
 rflx(:,:)=0._r8
 sflx(:,:)=0._r8
@@ -1900,6 +1977,12 @@ do i=1,ncol
 
          if (.not. use_hetfrz_classnuc) then
 
+!AL
+!Make sure zero output for deposition freezing
+!If no classnuc this is included in NNUCCD (Meyers 1992)
+            nnudep(k) = 0.0_r8
+            mnudep(k) = 0.0_r8
+!AL
             if (do_cldice .and. qcic(i,k).ge.qsmall .and. t(i,k).lt.269.15_r8) then
 
                ! immersion freezing (Bigg, 1953)
@@ -2563,6 +2646,27 @@ do i=1,ncol
          praio(i,k)=praio(i,k)+prai(k)*icldm(i,k)
          mnuccro(i,k)=mnuccro(i,k)+mnuccr(k)*cldmax(i,k)
          pracso (i,k)=pracso (i,k)+pracs (k)*cldmax(i,k)
+!AL
+         mnudepo(i,k)=mnudepo(i,k)+mnudep(k)*lcldm(i,k)  
+
+         ! microphysics output for number concentration tendencies
+         ! for liq.
+         nnuccco(i,k)=nnuccco(i,k)+nnuccc(k)*lcldm(i,k)
+         nnuccto(i,k)=nnuccto(i,k)+nnucct(k)*lcldm(i,k)
+         npsacwso(i,k)=npsacwso(i,k)+npsacws(k)*lcldm(i,k)
+         nsubco(i,k)=nsubco(i,k)+nsubc(k)*lcldm(i,k)  
+         nprao(i,k)=nprao(i,k)+npra(k)*lcldm(i,k)     
+         nprc1o(i,k)=nprc1o(i,k)+nprc1(k)*lcldm(i,k) 
+         npccno(i,k)=npccno(i,k)+npccn(k)*mtime           
+
+         ! for ice
+         nsacwio(i,k)=nsacwio(i,k)+nsacwi(k)*lcldm(i,k) 
+         nsubio(i,k)=nsubio(i,k)+nsubi(k)*icldm(i,k) 
+         nprcio(i,k)=nprcio(i,k)+nprci(k)*icldm(i,k) 
+         npraio(i,k)=npraio(i,k)+nprai(k)*icldm(i,k) 
+         nnudepo(i,k)=nnudepo(i,k)+nnudep(k)*lcldm(i,k)  
+         nnuccdo(i,k)=nnuccdo(i,k)+nnuccd(k)*mtime      
+!AL
 
          ! multiply activation/nucleation by mtime to account for fast timescale
 
@@ -2591,10 +2695,12 @@ do i=1,ncol
          ! fast nucleation timescale
 
          if (nctend(i,k).gt.0._r8.and.nc(i,k)+nctend(i,k)*deltat.gt.ncmax) then
+            nctncons(i,k) = nctncons(i,k) + nctend(i,k)-max(0._r8,(ncmax-nc(i,k))/deltat) !AL
             nctend(i,k)=max(0._r8,(ncmax-nc(i,k))/deltat)
          end if
 
          if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax) then
+            nitncons(i,k) = nitncons(i,k) + nitend(i,k)-max(0._r8,(nimax-ni(i,k))/deltat) !AL
             nitend(i,k)=max(0._r8,(nimax-ni(i,k))/deltat)
          end if
 
@@ -2993,6 +3099,25 @@ do i=1,ncol
 
       mnuccdo(i,k)=mnuccdo(i,k)/real(iter)
 
+!AL
+      mnudepo(i,k)=mnudepo(i,k)/real(iter)   
+      nnuccco(i,k)=nnuccco(i,k)/real(iter)   
+      nnuccto(i,k)=nnuccto(i,k)/real(iter)   
+      npsacwso(i,k)=npsacwso(i,k)/real(iter) 
+      nsubco(i,k)=nsubco(i,k)/real(iter)    
+      nprao(i,k)=nprao(i,k)/real(iter)       
+      nprc1o(i,k)=nprc1o(i,k)/real(iter)     
+      nsacwio(i,k)=nsacwio(i,k)/real(iter)   
+      nsubio(i,k)=nsubio(i,k)/real(iter)     
+      nprcio(i,k)=nprcio(i,k)/real(iter)     
+      npraio(i,k)=npraio(i,k)/real(iter)     
+      nnudepo(i,k)=nnudepo(i,k)/real(iter)   
+      nnuccdo(i,k)=nnuccdo(i,k)/real(iter)  
+      npccno(i,k)=npccno(i,k)/real(iter)   
+      nctncons(i,k)=nctncons(i,k)/real(iter)  
+      nitncons(i,k)=nitncons(i,k)/real(iter)  
+!AL
+
       ! modify to include snow. in prain & evap (diagnostic here: for wet dep)
       nevapr(i,k) = nevapr(i,k) + evapsnow(i,k)
       prer_evap(i,k) = nevapr2(i,k)
@@ -3137,6 +3262,10 @@ do i=1,ncol
       ! sedimentation tendencies for output
       qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
       qisedten(i,k)=qisedten(i,k)-faltndi/nstep
+!AL
+      nqcsedten(i,k)=nqcsedten(i,k)-faltndnc/nstep
+      nqisedten(i,k)=nqisedten(i,k)-faltndni/nstep
+!AL
 
       dumi(i,k) = dumi(i,k)-faltndi*deltat/nstep
       dumni(i,k) = dumni(i,k)-faltndni*deltat/nstep
@@ -3172,7 +3301,10 @@ do i=1,ncol
          ! sedimentation tendencies for output
          qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
          qisedten(i,k)=qisedten(i,k)-faltndi/nstep
-
+!AL
+         nqcsedten(i,k)=nqcsedten(i,k)-faltndnc/nstep
+         nqisedten(i,k)=nqisedten(i,k)-faltndni/nstep
+!AL
          ! add terms to to evap/sub of cloud water
 
          qvlat(i,k)=qvlat(i,k)-(faltndqie-faltndi)/nstep
@@ -3263,7 +3395,12 @@ do i=1,ncol
 
                nctend(i,k)=nctend(i,k)+3._r8*dum*dumi(i,k)/deltat/ &
                     (4._r8*pi*5.12e-16_r8*rhow)
-
+!AL
+               ! for output
+               nmelto(i,k)=3._r8*dum*dumi(i,k)/deltat/ &
+                    (4._r8*pi*5.12e-16_r8*rhow)
+               nimelto(i,k)=nitend(i,k)-((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
+!AL
                qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))/deltat
                nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
                tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)/deltat
@@ -3295,6 +3432,11 @@ do i=1,ncol
                nitend(i,k)=nitend(i,k)+dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
                     500._r8)/deltat
                qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))/deltat
+!AL
+               nhomoo(i,k)=nctend(i,k)-((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
+               nihomoo(i,k)=dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
+                    500._r8)/deltat
+!AL
                nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
                tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)/deltat
             end if
@@ -3386,14 +3528,19 @@ do i=1,ncol
             n0i(k) = lami(k)**(di+1._r8)*dumi(i,k)/(ci*cons1)
             niic(i,k) = n0i(k)/lami(k)
             ! adjust number conc if needed to keep mean size in reasonable range
-            if (do_cldice) nitend(i,k)=(niic(i,k)*icldm(i,k)-ni(i,k))/deltat
-
+            if (do_cldice) then
+               nitnszmn(i,k)=nitnszmn(i,k) + nitend(i,k)-(niic(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
+               nitend(i,k)=(niic(i,k)*icldm(i,k)-ni(i,k))/deltat
+            endif
          else if (lami(k).gt.lammaxi) then
             lami(k) = lammaxi
             n0i(k) = lami(k)**(di+1._r8)*dumi(i,k)/(ci*cons1)
             niic(i,k) = n0i(k)/lami(k)
             ! adjust number conc if needed to keep mean size in reasonable range
-            if (do_cldice) nitend(i,k)=(niic(i,k)*icldm(i,k)-ni(i,k))/deltat
+            if (do_cldice)then
+               nitnszmx(i,k)=nitnszmx(i,k) + nitend(i,k)-(niic(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
+               nitend(i,k)=(niic(i,k)*icldm(i,k)-ni(i,k))/deltat
+            endif
          end if
          effi(i,k) = 1.5_r8/lami(k)*1.e6_r8
 
@@ -3427,8 +3574,11 @@ do i=1,ncol
          ! set tendency to ensure minimum droplet concentration
          ! after update by microphysics, except when lambda exceeds bounds on mean drop
          ! size or if there is no cloud water
-         if (dumnc(i,k).lt.cdnl/rho(i,k)) then   
-            nctend(i,k)=(cdnl/rho(i,k)*lcldm(i,k)-nc(i,k))/deltat   
+         if (dumnc(i,k).lt.cdnl/rho(i,k)) then
+!AL
+            nctnnbmn(i,k)=nctnnbmn(i,k) + nctend(i,k)-(cdnl/rho(i,k)*lcldm(i,k)-nc(i,k))/deltat
+!AL 
+            nctend(i,k)=(cdnl/rho(i,k)*lcldm(i,k)-nc(i,k))/deltat  
          end if
          dumnc(i,k)=max(dumnc(i,k),cdnl/rho(i,k)) ! sghan minimum in #/cm3 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -3448,6 +3598,9 @@ do i=1,ncol
                  gamma(pgam(k)+1._r8)/ &
                  (pi*rhow*gamma(pgam(k)+4._r8))
             ! adjust number conc if needed to keep mean size in reasonable range
+!AL
+            nctnszmn(i,k)=nctnszmn(i,k) + nctend(i,k)-(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
+!AL 
             nctend(i,k)=(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
 
          else if (lamc(k).gt.lammax) then
@@ -3456,6 +3609,9 @@ do i=1,ncol
                  gamma(pgam(k)+1._r8)/ &
                  (pi*rhow*gamma(pgam(k)+4._r8))
             ! adjust number conc if needed to keep mean size in reasonable range
+!AL
+            nctnszmx(i,k)=nctnszmx(i,k) + nctend(i,k)-(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
+!AL 
             nctend(i,k)=(ncic(i,k)*lcldm(i,k)-nc(i,k))/deltat
          end if
 
@@ -3519,8 +3675,14 @@ do i=1,ncol
    do k=top_lev,pver
       ! if updated q (after microphysics) is zero, then ensure updated n is also zero
 
-      if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) nctend(i,k)=-nc(i,k)/deltat
-      if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall) nitend(i,k)=-ni(i,k)/deltat
+      if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) then !AL
+         nctnncld(i,k) = nctnncld(i,k) + nctend(i,k) +nc(i,k)/deltat
+         nctend(i,k)=-nc(i,k)/deltat
+      endif
+      if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall)then !AL
+         nitnncld(i,k) = nitnncld(i,k) + nitend(i,k) +ni(i,k)/deltat
+         nitend(i,k)=-ni(i,k)/deltat
+      endif
    end do
 
 end do ! i loop

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -438,7 +438,17 @@ subroutine micro_mg_tend ( &
      qgout2,        ngout2,        dgout2,    freqg,                   &
      freqs,                        freqr,                        &
      nfice,                        qcrat,                        &
-     errstring, & ! Below arguments are "optional" (pass null pointers to omit).
+     errstring,                                                  &
+!AL right names?
+     nnuccctot, nnuccttot, npsacwstot, nsubctot, npratot,       &
+     nprc1tot, ncsedtentot, nisedtentot, nmelttot, nhomotot,    &
+     nimelttot, nihomotot, nsacwitot, nsubitot, nprcitot,       &
+     npraitot, nnudeptot, npccntot, nnuccdtot, mnudeptot,       &
+     frzr,nfrzr, nnuccritot, mnuccritot,                        &
+!
+     nctnszmx,nctnszmn, nctnncld, nitncons, nitnszmx,nitnszmn, nitnncld, &
+!AL
+  ! Below arguments are "optional" (pass null pointers to omit).
      tnd_qsnow,          tnd_nsnow,          re_ice,             &
      prer_evap,                                                      &
      frzimm,             frzcnt,             frzdep)
@@ -659,6 +669,44 @@ subroutine micro_mg_tend ( &
   real(r8), intent(out) :: prer_evap(mgncol,nlev)
 
   character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
+
+!AL change these to tot? output is now called tot and packed in interface?
+ real(r8), intent(out) :: nnuccctot(mgncol,nlev)   ! immersion freezing
+ real(r8), intent(out) :: nnuccttot(mgncol,nlev)   ! contact freezing
+ real(r8), intent(out) :: npsacwstot(mgncol,nlev)  ! accr. snow
+ real(r8), intent(out) :: nsubctot(mgncol,nlev)    ! evaporation of droplet 
+ real(r8), intent(out) :: npratot(mgncol,nlev)     ! accretion
+ real(r8), intent(out) :: nprc1tot(mgncol,nlev)    ! autoconversion
+ real(r8), intent(out) :: ncsedtentot(mgncol,nlev) ! nqc sedimentation tendency
+ real(r8), intent(out) :: nisedtentot(mgncol,nlev) ! nqi sedimentation tendency
+ real(r8), intent(out) :: nmelttot(mgncol,nlev)    ! nc melting of cloud ice
+ real(r8), intent(out) :: nhomotot(mgncol,nlev)    ! nc homogeneos freezign cloud water
+ real(r8), intent(out) :: nimelttot(mgncol,nlev)   ! ni melting of cloud ice
+ real(r8), intent(out) :: nihomotot(mgncol,nlev)   ! ni homogeneos freezign cloud water
+ real(r8), intent(out) :: nsacwitot(mgncol,nlev)   ! numb conc tend due to HM ice multiplication
+ real(r8), intent(out) :: nsubitot(mgncol,nlev)    ! evaporation of cloud ice number (sublimation?)
+ real(r8), intent(out) :: nprcitot(mgncol,nlev)    ! numb conc tend due to auto of cloud ice to snow
+ real(r8), intent(out) :: npraitot(mgncol,nlev)    ! numb conc tend due to accr of cloud ice by snow
+ real(r8), intent(out) :: nnudeptot(mgncol,nlev)   ! deposition?
+ real(r8), intent(out) :: npccntot(mgncol,nlev)    ! droplet activation
+ real(r8), intent(out) :: nnuccdtot(mgncol,nlev)   ! ni nucleation
+ real(r8), intent(out) :: mnudeptot(mgncol,nlev)   ! deposition (mass) 
+!
+ real(r8), intent(out) :: nctnszmx(mgncol,nlev)  ! nc tuning: maximum slope (reduction of number)
+ real(r8), intent(out) :: nctnszmn(mgncol,nlev)  ! nc tuning: minimum slope (increase of numer)
+ real(r8), intent(out) :: nctnncld(mgncol,nlev)  ! nc tuning: removal of nc when qc is zero after mg
+ real(r8), intent(out) :: nitncons(mgncol,nlev)  ! ni tuning to conserve numberi in substeps
+ real(r8), intent(out) :: nitnszmx(mgncol,nlev)  ! ni tuning: maximum slope
+ real(r8), intent(out) :: nitnszmn(mgncol,nlev)  ! ni tuning: minimum minimum slope
+ real(r8), intent(out) :: nitnncld(mgncol,nlev)  ! ni tuning: removal of ni when qi is zero after mg
+ real(r8), intent(out) :: mnuccritot(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to snow (1/s)
+ real(r8), intent(out) :: nnuccritot(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to snow (1/s)
+ real(r8), intent(out) :: frzr(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to ice (1/s)
+ real(r8), intent(out) :: nfrzr(mgncol,nlev)! ni tendency due to heterogeneous freezing of rain to ice (1/s)
+!AL
+
+
+
 
   ! Tendencies calculated by external schemes that can replace MG's native
   ! process tendencies.
@@ -1129,6 +1177,43 @@ subroutine micro_mg_tend ( &
   nmultg=0._r8
   nmultrg=0._r8
   npsacwg=0._r8
+
+!AL this is correct since output now is tot? add new term!
+  nnuccctot=0._r8
+  nnuccttot=0._r8
+  npsacwstot=0._r8
+  nsubctot=0._r8
+  npratot=0._r8
+  nprc1tot=0._r8
+  ncsedtentot=0._r8
+  nisedtentot=0._r8
+  nmelttot=0._r8
+  nhomotot=0._r8
+  nimelttot=0._r8
+  nihomotot=0._r8
+  nsacwitot=0._r8
+  nsubitot=0._r8
+  nprcitot=0._r8
+  npraitot=0._r8
+  nnudeptot=0._r8
+  npccntot=0._r8
+  nnuccdtot=0._r8
+  mnudeptot=0._r8 
+  mnuccritot=0._r8
+  nnuccritot=0._r8
+
+  nctnszmx=0._r8
+  nctnszmn=0._r8
+  nctnncld=0._r8
+  nitncons=0._r8
+  nitnszmx=0._r8
+  nitnszmn=0._r8
+  nitnncld=0._r8
+
+  frzr=0._r8
+  nfrzr=0._r8
+
+!AL
 
   rflx=0._r8
   sflx=0._r8
@@ -2367,6 +2452,28 @@ subroutine micro_mg_tend ( &
         pracstot(i,k) = pracs(i,k)*precip_frac(i,k)
         mnuccrtot(i,k) = mnuccr(i,k)*precip_frac(i,k)
         mnuccritot(i,k) = mnuccri(i,k)*precip_frac(i,k)
+!AL
+        mnudeptot(i,k)=mnudep(i,k)*lcldm(i,k)
+
+           ! microphysics output for number concentration tendencies
+           ! for liq.
+        nnuccctot(i,k)=nnuccc(i,k)*lcldm(i,k)
+        nnuccttot(i,k)=nnucct(i,k)*lcldm(i,k)
+        npsacwstot(i,k)=npsacws(i,k)*lcldm(i,k)
+        nsubctot(i,k)=nsubc(i,k)*lcldm(i,k)
+        npratot(i,k)=npra(i,k)*lcldm(i,k)
+        nprc1tot(i,k)=nprc1(i,k)*lcldm(i,k)
+
+           ! for ice
+        nsacwitot(i,k)=nsacwi(i,k)*lcldm(i,k)
+        nsubitot(i,k)=nsubi(i,k)*icldm(i,k)
+        nprcitot(i,k)=nprci(i,k)*icldm(i,k)
+        npraitot(i,k)=nprai(i,k)*icldm(i,k)
+        nnudeptot(i,k)=nnudep(i,k)*lcldm(i,k)
+        nnuccdtot(i,k)=nnuccd(i,k)
+        nnuccritot(i,k) = nnuccri(i,k)*precip_frac(i,k)
+
+!AL
 
         psacrtot(i,k) = psacr(i,k)*precip_frac(i,k)
         pracgtot(i,k) = pracg(i,k)*precip_frac(i,k)
@@ -2422,6 +2529,7 @@ subroutine micro_mg_tend ( &
         !================================================================
 
         if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax(i,k)) then
+          nitncons(i,k) = nitncons(i,k) + nitend(i,k)-max(0._r8,(nimax(i,k)-ni(i,k))/deltat) !AL
            nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
         end if
 
@@ -2473,6 +2581,9 @@ subroutine micro_mg_tend ( &
   ! Re-apply droplet activation tendency
   nc = ncn
   nctend = nctend + npccn
+!AL
+  npccntot = npccn
+!AL
 
   ! Re-apply rain freezing and snow melting.
   dum_2D = qs
@@ -2749,6 +2860,9 @@ subroutine micro_mg_tend ( &
 
         ! sedimentation tendency for output
         qisedten(i,k)=qisedten(i,k)-faltndi/nstep
+!AL
+        nisedtentot(i,k)=nisedtentot(i,k)-faltndni/nstep
+!AL
 
         dumi(i,k) = dumi(i,k)-faltndi*deltat/nstep
         dumni(i,k) = dumni(i,k)-faltndni*deltat/nstep
@@ -2775,6 +2889,9 @@ subroutine micro_mg_tend ( &
 
            ! sedimentation tendency for output
            qisedten(i,k)=qisedten(i,k)-faltndi/nstep
+!AL
+        nisedtentot(i,k)=nisedtentot(i,k)-faltndni/nstep
+!AL
 
            ! add terms to to evap/sub of cloud water
 
@@ -2829,6 +2946,9 @@ subroutine micro_mg_tend ( &
 
         ! sedimentation tendency for output
         qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
+!AL
+        ncsedtentot(i,k)=ncsedtentot(i,k)-faltndnc/nstep
+!AL
 
         dumc(i,k) = dumc(i,k)-faltndc*deltat/nstep
         dumnc(i,k) = dumnc(i,k)-faltndnc*deltat/nstep
@@ -2847,6 +2967,9 @@ subroutine micro_mg_tend ( &
 
            ! sedimentation tendency for output
            qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
+!AL
+        ncsedtentot(i,k)=ncsedtentot(i,k)-faltndnc/nstep
+!AL
 
            ! add terms to to evap/sub of cloud water
            qvlat(i,k)=qvlat(i,k)-(faltndqce-faltndc)/nstep
@@ -3199,6 +3322,10 @@ subroutine micro_mg_tend ( &
               else
                  qitend(i,k)=qitend(i,k)+dum*dumr(i,k)/deltat
                  nitend(i,k)=nitend(i,k)+dum*dumnr(i,k)/deltat
+!AL
+                 frzr(i,k)=frzr(i,k)+dum*dumr(i,k)/deltat
+                 nfrzr(i,k)=nfrzr(i,k)+dum*dumnr(i,k)/deltat
+!AL
               end if
 
               ! heating tendency
@@ -3241,6 +3368,13 @@ subroutine micro_mg_tend ( &
                  nctend(i,k)=nctend(i,k)+3._r8*dum*dumi(i,k)/deltat/ &
                       (4._r8*pi*5.12e-16_r8*rhow)
 
+!AL
+               ! for output
+                 nmelttot(i,k)=3._r8*dum*dumi(i,k)/deltat/ &
+                      (4._r8*pi*5.12e-16_r8*rhow)
+                 nimelttot(i,k)=nitend(i,k)-((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
+!AL
+
                  qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))/deltat
                  nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
                  tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)/deltat
@@ -3277,6 +3411,12 @@ subroutine micro_mg_tend ( &
                  nitend(i,k)=nitend(i,k)+dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
                       500._r8)/deltat
                  qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))/deltat
+
+!AL
+                 nhomotot(i,k)=nctend(i,k)-((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
+                 nihomotot(i,k)=dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
+                      500._r8)/deltat
+!AL
                  nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
                  tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)/deltat
               end if
@@ -3390,6 +3530,12 @@ subroutine micro_mg_tend ( &
 
               if (dumni(i,k) /=dum_2D(i,k)) then
                  ! adjust number conc if needed to keep mean size in reasonable range
+                 if (dumni(i,k)<dum_2D(i,k)) then
+                    nitnszmx(i,k)=nitnszmx(i,k) + nitend(i,k)-(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
+                 else
+                    nitnszmn(i,k)=nitnszmn(i,k) + nitend(i,k)-(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
+                 endif
+
                  nitend(i,k)=(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat
               end if
 
@@ -3442,6 +3588,11 @@ subroutine micro_mg_tend ( &
 
            if (dum /= dumnc(i,k)) then
               ! adjust number conc if needed to keep mean size in reasonable range
+              if (dumnc(i,k)<dum) then
+                 nctnszmx(i,k)=nctnszmx(i,k) + nctend(i,k)-(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat !AL
+              else
+                 nctnszmn(i,k)=nctnszmn(i,k) + nctend(i,k)-(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat !AL
+              endif
               nctend(i,k)=(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat
            end if
 
@@ -3548,8 +3699,14 @@ subroutine micro_mg_tend ( &
      do i=1,mgncol
         ! if updated q (after microphysics) is zero, then ensure updated n is also zero
         !=================================================================================
-        if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall) nctend(i,k)=-nc(i,k)/deltat
-        if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall) nitend(i,k)=-ni(i,k)/deltat
+        if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall)  then !AL
+           nctnncld(i,k) = nctnncld(i,k) + nctend(i,k) +nc(i,k)/deltat !AL
+           nctend(i,k)=-nc(i,k)/deltat
+        endif
+        if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall)then !AL
+            nitnncld(i,k) = nitnncld(i,k) + nitend(i,k) +ni(i,k)/deltat
+            nitend(i,k)=-ni(i,k)/deltat
+        endif
         if (qr(i,k)+qrtend(i,k)*deltat.lt.qsmall) nrtend(i,k)=-nr(i,k)/deltat
         if (qs(i,k)+qstend(i,k)*deltat.lt.qsmall) nstend(i,k)=-ns(i,k)/deltat
         if (qg(i,k)+qgtend(i,k)*deltat.lt.qsmall) ngtend(i,k)=-ng(i,k)/deltat

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -444,7 +444,7 @@ subroutine micro_mg_tend ( &
      nprc1tot, ncsedtentot, nisedtentot, nmelttot, nhomotot,    &
      nimelttot, nihomotot, nsacwitot, nsubitot, nprcitot,       &
      npraitot, nnudeptot, npccntot, nnuccdtot, mnudeptot,       &
-     frzr,nfrzr, nnuccritot, mnuccritot,                        &
+     frzr,nfrzr, nnuccritot,                                    &
 !
      nctnszmx,nctnszmn, nctnncld, nitncons, nitnszmx,nitnszmn, nitnncld, &
 !AL
@@ -699,7 +699,6 @@ subroutine micro_mg_tend ( &
  real(r8), intent(out) :: nitnszmx(mgncol,nlev)  ! ni tuning: maximum slope
  real(r8), intent(out) :: nitnszmn(mgncol,nlev)  ! ni tuning: minimum minimum slope
  real(r8), intent(out) :: nitnncld(mgncol,nlev)  ! ni tuning: removal of ni when qi is zero after mg
- real(r8), intent(out) :: mnuccritot(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to snow (1/s)
  real(r8), intent(out) :: nnuccritot(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to snow (1/s)
  real(r8), intent(out) :: frzr(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to ice (1/s)
  real(r8), intent(out) :: nfrzr(mgncol,nlev)! ni tendency due to heterogeneous freezing of rain to ice (1/s)
@@ -1199,7 +1198,6 @@ subroutine micro_mg_tend ( &
   npccntot=0._r8
   nnuccdtot=0._r8
   mnudeptot=0._r8 
-  mnuccritot=0._r8
   nnuccritot=0._r8
 
   nctnszmx=0._r8

--- a/micro_mg3_0.F90
+++ b/micro_mg3_0.F90
@@ -439,7 +439,8 @@ subroutine micro_mg_tend ( &
      freqs,                        freqr,                        &
      nfice,                        qcrat,                        &
      errstring,                                                  &
-!AL right names?
+!AL++ right names?
+#ifdef OSLO_AERO
      nnuccctot, nnuccttot, npsacwstot, nsubctot, npratot,       &
      nprc1tot, ncsedtentot, nisedtentot, nmelttot, nhomotot,    &
      nimelttot, nihomotot, nsacwitot, nsubitot, nprcitot,       &
@@ -447,7 +448,8 @@ subroutine micro_mg_tend ( &
      frzr,nfrzr, nnuccritot,                                    &
 !
      nctnszmx,nctnszmn, nctnncld, nitncons, nitnszmx,nitnszmn, nitnncld, &
-!AL
+#endif
+!AL--
   ! Below arguments are "optional" (pass null pointers to omit).
      tnd_qsnow,          tnd_nsnow,          re_ice,             &
      prer_evap,                                                      &
@@ -670,7 +672,8 @@ subroutine micro_mg_tend ( &
 
   character(128),   intent(out) :: errstring  ! output status (non-blank for error return)
 
-!AL change these to tot? output is now called tot and packed in interface?
+!AL++ change these to tot? output is now called tot and packed in interface?
+#ifdef OSLO_AERO
  real(r8), intent(out) :: nnuccctot(mgncol,nlev)   ! immersion freezing
  real(r8), intent(out) :: nnuccttot(mgncol,nlev)   ! contact freezing
  real(r8), intent(out) :: npsacwstot(mgncol,nlev)  ! accr. snow
@@ -702,10 +705,8 @@ subroutine micro_mg_tend ( &
  real(r8), intent(out) :: nnuccritot(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to snow (1/s)
  real(r8), intent(out) :: frzr(mgncol,nlev)! mixing ratio tendency due to heterogeneous freezing of rain to ice (1/s)
  real(r8), intent(out) :: nfrzr(mgncol,nlev)! ni tendency due to heterogeneous freezing of rain to ice (1/s)
-!AL
-
-
-
+#endif
+!AL--
 
   ! Tendencies calculated by external schemes that can replace MG's native
   ! process tendencies.
@@ -1177,7 +1178,8 @@ subroutine micro_mg_tend ( &
   nmultrg=0._r8
   npsacwg=0._r8
 
-!AL this is correct since output now is tot? add new term!
+!AL++ this is correct since output now is tot? add new term!
+#ifdef OSLO_AERO
   nnuccctot=0._r8
   nnuccttot=0._r8
   npsacwstot=0._r8
@@ -1210,8 +1212,8 @@ subroutine micro_mg_tend ( &
 
   frzr=0._r8
   nfrzr=0._r8
-
-!AL
+#endif
+!AL--
 
   rflx=0._r8
   sflx=0._r8
@@ -2450,7 +2452,8 @@ subroutine micro_mg_tend ( &
         pracstot(i,k) = pracs(i,k)*precip_frac(i,k)
         mnuccrtot(i,k) = mnuccr(i,k)*precip_frac(i,k)
         mnuccritot(i,k) = mnuccri(i,k)*precip_frac(i,k)
-!AL
+!AL++
+#ifdef OSLO_AERO
         mnudeptot(i,k)=mnudep(i,k)*lcldm(i,k)
 
            ! microphysics output for number concentration tendencies
@@ -2470,8 +2473,8 @@ subroutine micro_mg_tend ( &
         nnudeptot(i,k)=nnudep(i,k)*lcldm(i,k)
         nnuccdtot(i,k)=nnuccd(i,k)
         nnuccritot(i,k) = nnuccri(i,k)*precip_frac(i,k)
-
-!AL
+#endif
+!AL--
 
         psacrtot(i,k) = psacr(i,k)*precip_frac(i,k)
         pracgtot(i,k) = pracg(i,k)*precip_frac(i,k)
@@ -2527,7 +2530,11 @@ subroutine micro_mg_tend ( &
         !================================================================
 
         if (do_cldice .and. nitend(i,k).gt.0._r8.and.ni(i,k)+nitend(i,k)*deltat.gt.nimax(i,k)) then
+!AL++
+#ifdef OSLO_AERO
           nitncons(i,k) = nitncons(i,k) + nitend(i,k)-max(0._r8,(nimax(i,k)-ni(i,k))/deltat) !AL
+#endif
+!AL--
            nitend(i,k)=max(0._r8,(nimax(i,k)-ni(i,k))/deltat)
         end if
 
@@ -2579,9 +2586,11 @@ subroutine micro_mg_tend ( &
   ! Re-apply droplet activation tendency
   nc = ncn
   nctend = nctend + npccn
-!AL
+!AL++
+#ifdef OSLO_AERO
   npccntot = npccn
-!AL
+#endif
+!AL--
 
   ! Re-apply rain freezing and snow melting.
   dum_2D = qs
@@ -2858,9 +2867,11 @@ subroutine micro_mg_tend ( &
 
         ! sedimentation tendency for output
         qisedten(i,k)=qisedten(i,k)-faltndi/nstep
-!AL
+!AL++
+#ifdef OSLO_AERO
         nisedtentot(i,k)=nisedtentot(i,k)-faltndni/nstep
-!AL
+#endif
+!AL--
 
         dumi(i,k) = dumi(i,k)-faltndi*deltat/nstep
         dumni(i,k) = dumni(i,k)-faltndni*deltat/nstep
@@ -2887,9 +2898,11 @@ subroutine micro_mg_tend ( &
 
            ! sedimentation tendency for output
            qisedten(i,k)=qisedten(i,k)-faltndi/nstep
-!AL
+!AL++
+#ifdef OSLO_AERO
         nisedtentot(i,k)=nisedtentot(i,k)-faltndni/nstep
-!AL
+#endif
+!AL--
 
            ! add terms to to evap/sub of cloud water
 
@@ -2944,9 +2957,11 @@ subroutine micro_mg_tend ( &
 
         ! sedimentation tendency for output
         qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
-!AL
+!AL++
+#ifdef OSLO_AERO
         ncsedtentot(i,k)=ncsedtentot(i,k)-faltndnc/nstep
-!AL
+#endif
+!AL--
 
         dumc(i,k) = dumc(i,k)-faltndc*deltat/nstep
         dumnc(i,k) = dumnc(i,k)-faltndnc*deltat/nstep
@@ -2965,9 +2980,11 @@ subroutine micro_mg_tend ( &
 
            ! sedimentation tendency for output
            qcsedten(i,k)=qcsedten(i,k)-faltndc/nstep
-!AL
+!AL++
+#ifdef OSLO_AERO
         ncsedtentot(i,k)=ncsedtentot(i,k)-faltndnc/nstep
-!AL
+#endif
+!AL--
 
            ! add terms to to evap/sub of cloud water
            qvlat(i,k)=qvlat(i,k)-(faltndqce-faltndc)/nstep
@@ -3320,10 +3337,12 @@ subroutine micro_mg_tend ( &
               else
                  qitend(i,k)=qitend(i,k)+dum*dumr(i,k)/deltat
                  nitend(i,k)=nitend(i,k)+dum*dumnr(i,k)/deltat
-!AL
+!AL++
+#ifdef OSLO_AERO
                  frzr(i,k)=frzr(i,k)+dum*dumr(i,k)/deltat
                  nfrzr(i,k)=nfrzr(i,k)+dum*dumnr(i,k)/deltat
-!AL
+#endif
+!AL--
               end if
 
               ! heating tendency
@@ -3366,13 +3385,14 @@ subroutine micro_mg_tend ( &
                  nctend(i,k)=nctend(i,k)+3._r8*dum*dumi(i,k)/deltat/ &
                       (4._r8*pi*5.12e-16_r8*rhow)
 
-!AL
+!AL++
+#ifdef OSLO_AERO
                ! for output
                  nmelttot(i,k)=3._r8*dum*dumi(i,k)/deltat/ &
                       (4._r8*pi*5.12e-16_r8*rhow)
                  nimelttot(i,k)=nitend(i,k)-((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
-!AL
-
+#endif
+!AL--
                  qitend(i,k)=((1._r8-dum)*dumi(i,k)-qi(i,k))/deltat
                  nitend(i,k)=((1._r8-dum)*dumni(i,k)-ni(i,k))/deltat
                  tlat(i,k)=tlat(i,k)-xlf*dum*dumi(i,k)/deltat
@@ -3409,12 +3429,13 @@ subroutine micro_mg_tend ( &
                  nitend(i,k)=nitend(i,k)+dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
                       500._r8)/deltat
                  qctend(i,k)=((1._r8-dum)*dumc(i,k)-qc(i,k))/deltat
-
-!AL
+!AL++
+#ifdef OSLO_AERO
                  nhomotot(i,k)=nctend(i,k)-((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
                  nihomotot(i,k)=dum*3._r8*dumc(i,k)/(4._r8*3.14_r8*1.563e-14_r8* &
                       500._r8)/deltat
-!AL
+#endif
+!AL--
                  nctend(i,k)=((1._r8-dum)*dumnc(i,k)-nc(i,k))/deltat
                  tlat(i,k)=tlat(i,k)+xlf*dum*dumc(i,k)/deltat
               end if
@@ -3528,12 +3549,15 @@ subroutine micro_mg_tend ( &
 
               if (dumni(i,k) /=dum_2D(i,k)) then
                  ! adjust number conc if needed to keep mean size in reasonable range
+!AL++
+#ifdef OSLO_AERO
                  if (dumni(i,k)<dum_2D(i,k)) then
                     nitnszmx(i,k)=nitnszmx(i,k) + nitend(i,k)-(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
                  else
                     nitnszmn(i,k)=nitnszmn(i,k) + nitend(i,k)-(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat !AL
                  endif
-
+#endif
+!AL--
                  nitend(i,k)=(dumni(i,k)*icldm(i,k)-ni(i,k))/deltat
               end if
 
@@ -3586,11 +3610,15 @@ subroutine micro_mg_tend ( &
 
            if (dum /= dumnc(i,k)) then
               ! adjust number conc if needed to keep mean size in reasonable range
+!AL++
+#ifdef OSLO_AERO
               if (dumnc(i,k)<dum) then
                  nctnszmx(i,k)=nctnszmx(i,k) + nctend(i,k)-(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat !AL
               else
                  nctnszmn(i,k)=nctnszmn(i,k) + nctend(i,k)-(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat !AL
               endif
+#endif
+!AL--
               nctend(i,k)=(dumnc(i,k)*lcldm(i,k)-nc(i,k))/deltat
            end if
 
@@ -3698,11 +3726,19 @@ subroutine micro_mg_tend ( &
         ! if updated q (after microphysics) is zero, then ensure updated n is also zero
         !=================================================================================
         if (qc(i,k)+qctend(i,k)*deltat.lt.qsmall)  then !AL
+!AL++
+#ifdef OSLO_AERO
            nctnncld(i,k) = nctnncld(i,k) + nctend(i,k) +nc(i,k)/deltat !AL
+#endif
+!AL--
            nctend(i,k)=-nc(i,k)/deltat
         endif
         if (do_cldice .and. qi(i,k)+qitend(i,k)*deltat.lt.qsmall)then !AL
+!AL++
+#ifdef OSLO_AERO
             nitnncld(i,k) = nitnncld(i,k) + nitend(i,k) +ni(i,k)/deltat
+#endif
+!AL--
             nitend(i,k)=-ni(i,k)/deltat
         endif
         if (qr(i,k)+qrtend(i,k)*deltat.lt.qsmall) nrtend(i,k)=-nr(i,k)/deltat


### PR DESCRIPTION
The modifications in micro_mg1_0.F90 and micro_mg3_0.F90 are all introduced with #ifdef OSLO_AERO.  So one should be able to find pure CESM results of OSLO_AERO is not set.